### PR TITLE
dependabot: use reviewers not assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
-  assignees: ["bringg/devops"]
+  reviewers: ["bringg/devops"]
   schedule:
     interval: "weekly"
     day: saturday


### PR DESCRIPTION
`assignees` are for individuals, so we will use `reviewers` which accepts github teams in additional to users